### PR TITLE
fix: set default for PRIVATE_NODE_NET_NAME

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,4 +73,4 @@ services:
 networks:
   private-peregrine-rpc-node-net:
     external: ${PRIVATE_NODE_ENABLE:-false}
-    name: ${PRIVATE_NODE_NET_NAME:-"none"}
+    name: ${PRIVATE_NODE_NET_NAME:-nonet}


### PR DESCRIPTION
## fixes KILTProtocol/ticket#NoTicket

Allows running project without setting the env constant `PRIVATE_NODE_NET_NAME` .