### PR TITLE
fix: wait for block finalization

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -33,7 +33,7 @@ jobs:
           docker build \
             --build-arg CRAWL_PEREGRINE=false \
             --build-arg RPC_ENDPOINTS=${{ vars.RPC_ENDPOINTS }} \
-            -t indexer:dev .
+            -t indexer:prod .
 
       - name: Tag, and push image to Amazon ECR
         env:


### PR DESCRIPTION
## fixes KILTProtocol/NoTicket

Processing same events twice on different blocks was crashing the sub-query node, because the information was incompatible with the data base. Incompatible information should do crash the sub-query node.

To avoid having incompatible information delivered by the blockchain node, it is better to wait for finalization. 