### PR TITLE
fix: wait for block finalization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - --db-schema=app
       - --workers=4
       - --batch-size=30
-      - --unfinalized-blocks=true
+      - --unfinalized-blocks=false
       # - --log-level=trace # uncomment for debugging
     healthcheck:
       test: ["CMD", "curl", "-f", "http://subquery-node:3000/ready"]


### PR DESCRIPTION
## fixes KILTProtocol/NoTicket

Processing same events twice on different blocks was crashing the sub-query node, because the information was incompatible with the data base. Incompatible information should do crash the sub-query node.

To avoid having incompatible information delivered by the blockchain node, it is better to wait for finalization. 